### PR TITLE
Fix links to supplementary material

### DIFF
--- a/_posts/2011-06-14-agarwal11a.md
+++ b/_posts/2011-06-14-agarwal11a.md
@@ -1,6 +1,6 @@
 ---
 title: Discussion of “Learning Scale Free Networks by Reweighted L1 regularization”
-abstract: Discussion of <a href="http://jmlr.org/proceedings/papers/v15/liu11a.html">Learning
+abstract: Discussion of <a href="http:liu11a.html">Learning
   Scale Free Networks by Reweighted L1 regularization</a>.
 pdf: http://proceedings.mlr.press/v15/agarwal11a/agarwal11a.pdf
 section: notable

--- a/_posts/2011-06-14-ahmed11a.md
+++ b/_posts/2011-06-14-ahmed11a.md
@@ -9,7 +9,7 @@ abstract: We present the time-dependent topic-cluster model, a hierarchical appr
   of a parallel Sequential Monte Carlo algorithm to perform inference in the resulting
   graphical model which scales to hundred of thousands of documents. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/ahmed11a/ahmed11a.pdf
-supplementary: http://proceedings.mlr.press/v15/ahmed11a///jmlr.org/proceedings/papers/v15/ahmed11a/ahmed11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/ahmed11a/ahmed11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: ahmed11a

--- a/_posts/2011-06-14-airoldi11a.md
+++ b/_posts/2011-06-14-airoldi11a.md
@@ -13,7 +13,7 @@ abstract: 'We consider linear ill-posed inverse problems y=Ax, in which we want 
   on uniform distributions.   We showcase one of these samplers on simulated and real
   data.  [pdf][supplementary]'
 pdf: http://proceedings.mlr.press/v15/airoldi11a/airoldi11a.pdf
-supplementary: http://proceedings.mlr.press/v15/airoldi11a///jmlr.org/proceedings/papers/v15/airoldi11a/airoldi11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/airoldi11a/airoldi11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: airoldi11a

--- a/_posts/2011-06-14-azar11a.md
+++ b/_posts/2011-06-14-azar11a.md
@@ -14,7 +14,7 @@ abstract: In this paper, we consider the problem of planning   in the infinite-h
   observe that approximate DPP  asymptotically outperforms other methods on the mountain-car
   problem.  [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/azar11a/azar11a.pdf
-supplementary: http://proceedings.mlr.press/v15/azar11a///jmlr.org/proceedings/papers/v15/azar11a/azar11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/azar11a/azar11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: azar11a

--- a/_posts/2011-06-14-bellala11a.md
+++ b/_posts/2011-06-14-bellala11a.md
@@ -12,7 +12,7 @@ abstract: We consider a problem of active diagnosis, where the goal is to effici
   of the true object is optimized. Furthermore, our algorithm does not require knowledge
   of the query noise distribution. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/bellala11a/bellala11a.pdf
-supplementary: http://proceedings.mlr.press/v15/bellala11a///jmlr.org/proceedings/papers/v15/bellala11a/bellala11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/bellala11a/bellala11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: bellala11a

--- a/_posts/2011-06-14-bengio11a.md
+++ b/_posts/2011-06-14-bengio11a.md
@@ -1,6 +1,6 @@
 ---
 title: Discussion of “The Neural Autoregressive Distribution Estimator”
-abstract: Discussion of <a href="http://jmlr.org/proceedings/papers/v15/larochelle11a.html">The
+abstract: Discussion of <a href="http:larochelle11a.html">The
   Neural Autoregressive Distribution Estimator</a>.
 pdf: http://proceedings.mlr.press/v15/bengio11a/bengio11a.pdf
 section: notable

--- a/_posts/2011-06-14-beygelzimer11a.md
+++ b/_posts/2011-06-14-beygelzimer11a.md
@@ -15,7 +15,7 @@ abstract: 'We address the problem of competing with any large set of N policies 
   and bring us closer to providing guarantees for this setting that are comparable
   to those in standard supervised learning.  '
 pdf: http://proceedings.mlr.press/v15/beygelzimer11a/beygelzimer11a.pdf
-supplementary: http://proceedings.mlr.press/v15/beygelzimer11a///jmlr.org/proceedings/papers/v15/beygelzimer11a/beygelzimer11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/beygelzimer11a/beygelzimer11aSupple.pdf
 discussion: mcmahan11a.html
 layout: inproceedings
 series: Proceedings of Machine Learning Research

--- a/_posts/2011-06-14-blitzer11a.md
+++ b/_posts/2011-06-14-blitzer11a.md
@@ -12,7 +12,7 @@ abstract: 'Domain adaptation algorithms address a key issue in applied machine l
   on two natural language processing adaptation tasks which are characterized by novel
   target features. [pdf][supplementary]'
 pdf: http://proceedings.mlr.press/v15/blitzer11a/blitzer11a.pdf
-supplementary: http://proceedings.mlr.press/v15/blitzer11a///jmlr.org/proceedings/papers/v15/blitzer11a/blitzer11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/blitzer11a/blitzer11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: blitzer11a

--- a/_posts/2011-06-14-bracegirdle11a.md
+++ b/_posts/2011-06-14-bracegirdle11a.md
@@ -9,7 +9,7 @@ abstract: Reset models are constrained switching latent Markov models in which t
   routines that scale linearly with T. Applications are given to change-point models
   and reset linear dynamical systems. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/bracegirdle11a/bracegirdle11a.pdf
-supplementary: http://proceedings.mlr.press/v15/bracegirdle11a///jmlr.org/proceedings/papers/v15/bracegirdle11a/bracegirdle11aSupple.zip
+supplementary: http://proceedings.mlr.press/v15/bracegirdle11a/bracegirdle11aSupple.zip
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: bracegirdle11a

--- a/_posts/2011-06-14-challis11a.md
+++ b/_posts/2011-06-14-challis11a.md
@@ -13,7 +13,7 @@ abstract: Two popular approaches to forming bounds in approximate Bayesian infer
   obtain lower bounds on the marginal likelihood in large scale Bayesian linear models.
   [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/challis11a/challis11a.pdf
-supplementary: http://proceedings.mlr.press/v15/challis11a///jmlr.org/proceedings/papers/v15/challis11a/challis11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/challis11a/challis11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: challis11a

--- a/_posts/2011-06-14-collobert11a.md
+++ b/_posts/2011-06-14-collobert11a.md
@@ -8,7 +8,7 @@ abstract: We propose a new fast purely discriminative algorithm for natural lang
   discriminative parsers and existing “benchmark” parsers (like Collins parser, probabilistic
   context-free grammars based), with a huge speed advantage. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/collobert11a/collobert11a.pdf
-supplementary: http://proceedings.mlr.press/v15/collobert11a///jmlr.org/proceedings/papers/v15/collobert11a/collobert11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/collobert11a/collobert11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: collobert11a

--- a/_posts/2011-06-14-conitzer11a.md
+++ b/_posts/2011-06-14-conitzer11a.md
@@ -1,6 +1,6 @@
 ---
 title: Discussion of “A conditional game for comparing approximations”
-abstract: Discussion of <a href="http://jmlr.org/proceedings/papers/v15/eaton11a.html">A
+abstract: Discussion of <a href="http:eaton11a.html">A
   conditional game for comparing approximations</a>.
 pdf: http://proceedings.mlr.press/v15/conitzer11a/conitzer11a.pdf
 section: notable

--- a/_posts/2011-06-14-farahat11a.md
+++ b/_posts/2011-06-14-farahat11a.md
@@ -10,7 +10,7 @@ abstract: The NystrÃ¶m method is an efficient technique for obtaining a low-ra
   greedy algorithms achieve significant improvements in approximating kernel matrices,
   with minimum overhead in run time. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/farahat11a/farahat11a.pdf
-supplementary: http://proceedings.mlr.press/v15/farahat11a///jmlr.org/proceedings/papers/v15/farahat11a/farahat11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/farahat11a/farahat11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: farahat11a

--- a/_posts/2011-06-14-garg11a.md
+++ b/_posts/2011-06-14-garg11a.md
@@ -13,7 +13,7 @@ abstract: We propose Kernel Block Restricted Isometry Property (KB-RIP) as a gen
   only are our sum-of-norms-minimization formulation and combinatorial algorithm significantly
   faster than Lasso, they also outperforms Lasso in terms of recovery. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/garg11a/garg11a.pdf
-supplementary: http://proceedings.mlr.press/v15/garg11a///jmlr.org/proceedings/papers/v15/garg11a/garg11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/garg11a/garg11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: garg11a

--- a/_posts/2011-06-14-geurts11a.md
+++ b/_posts/2011-06-14-geurts11a.md
@@ -15,7 +15,7 @@ abstract: Given a finite but large set of objects described by a vector of featu
   out in Bioinformatics and its results outperform common solutions to this problem.
   [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/geurts11a/geurts11a.pdf
-supplementary: http://proceedings.mlr.press/v15/geurts11a///jmlr.org/proceedings/papers/v15/geurts11a/geurts11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/geurts11a/geurts11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: geurts11a

--- a/_posts/2011-06-14-gonzalez11a.md
+++ b/_posts/2011-06-14-gonzalez11a.md
@@ -17,7 +17,7 @@ abstract: We explore the task of constructing a parallel Gibbs sampler, to both 
   on large synthetic and real-world models using a 32 processor multi-core system.
   [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/gonzalez11a/gonzalez11a.pdf
-supplementary: http://proceedings.mlr.press/v15/gonzalez11a///jmlr.org/proceedings/papers/v15/gonzalez11a/gonzalez11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/gonzalez11a/gonzalez11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: gonzalez11a

--- a/_posts/2011-06-14-ho11a.md
+++ b/_posts/2011-06-14-ho11a.md
@@ -12,7 +12,7 @@ abstract: Real world networks exhibit a complex set of phenomena such as underly
   validation using synthetic networks, and demonstrate the utility of our model in
   real-world datasets such as predator-prey networks and citation networks. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/ho11a/ho11a.pdf
-supplementary: http://proceedings.mlr.press/v15/ho11a///jmlr.org/proceedings/papers/v15/ho11a/ho11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/ho11a/ho11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: ho11a

--- a/_posts/2011-06-14-ho11b.md
+++ b/_posts/2011-06-14-ho11b.md
@@ -13,7 +13,7 @@ abstract: Time-evolving networks are a natural presentation for dynamic social a
   utility as a network analysis tool, by applying it to United States Congress voting
   data. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/ho11b/ho11b.pdf
-supplementary: http://proceedings.mlr.press/v15/ho11b///jmlr.org/proceedings/papers/v15/ho11b/ho11bSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/ho11b/ho11bSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: ho11b

--- a/_posts/2011-06-14-hong11a.md
+++ b/_posts/2011-06-14-hong11a.md
@@ -16,7 +16,7 @@ abstract: 'Market-based algorithms have become popular in collaborative multi-ag
   the effectiveness of our algorithm in both centralized and distributed settings
   on synthetic planning problems. [pdf][supplementary]'
 pdf: http://proceedings.mlr.press/v15/hong11a/hong11a.pdf
-supplementary: http://proceedings.mlr.press/v15/hong11a///jmlr.org/proceedings/papers/v15/hong11a/hong11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/hong11a/hong11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: hong11a

--- a/_posts/2011-06-14-jalali11a.md
+++ b/_posts/2011-06-14-jalali11a.md
@@ -16,7 +16,7 @@ abstract: We study the problem of learning the graph structure associated with a
   more stringent conditions, the pairwise procedure still recovers the graph structure,  when
   the samples scale as n > K (m-1)^2 d^3/2c - 1 \log ( (m-1)^c (p-1)^c-1 ). [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/jalali11a/jalali11a.pdf
-supplementary: http://proceedings.mlr.press/v15/jalali11a///jmlr.org/proceedings/papers/v15/jalali11a/jalali11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/jalali11a/jalali11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: jalali11a

--- a/_posts/2011-06-14-kolar11a.md
+++ b/_posts/2011-06-14-kolar11a.md
@@ -11,7 +11,7 @@ abstract: The time-varying multivariate Gaussian distribution and the   undirect
   is shown for the procedure proposed in Zhou et al. (2008)   and for the modified
   neighborhood selection procedure of   Meinshausen and BÃ¼hlmann (2006). [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/kolar11a/kolar11a.pdf
-supplementary: http://proceedings.mlr.press/v15/kolar11a///jmlr.org/proceedings/papers/v15/kolar11a/kolar11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/kolar11a/kolar11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: kolar11a

--- a/_posts/2011-06-14-lacoste_julien11a.md
+++ b/_posts/2011-06-14-lacoste_julien11a.md
@@ -12,7 +12,7 @@ abstract: We consider the problem of approximate inference in the context of Bay
   improve a standard approach to Gaussian process classification when losses are asymmetric.
   [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/lacoste_julien11a/lacoste_julien11a.pdf
-supplementary: http://proceedings.mlr.press/v15/lacoste_julien11a///jmlr.org/proceedings/papers/v15/lacoste_julien11a/lacoste_julien11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/lacoste_julien11a/lacoste_julien11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: lacoste_julien11a

--- a/_posts/2011-06-14-li11c.md
+++ b/_posts/2011-06-14-li11c.md
@@ -15,7 +15,7 @@ abstract: Most clustering algorithms assume that all dimensions of the data can 
   speed- up relative to the full deterministic approxi- mation with minimal cost in
   predictive error. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/li11c/li11c.pdf
-supplementary: http://proceedings.mlr.press/v15/li11c///jmlr.org/proceedings/papers/v15/li11c/li11cSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/li11c/li11cSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: li11c

--- a/_posts/2011-06-14-maaten11a.md
+++ b/_posts/2011-06-14-maaten11a.md
@@ -1,6 +1,6 @@
 ---
 title: Discussion of “Spectral Dimensionality Reduction via Maximum Entropy”
-abstract: Discussion of <a href="http://jmlr.org/proceedings/papers/v15/lawrence11a.html">Spectral
+abstract: Discussion of <a href="http:lawrence11a.html">Spectral
   Dimensionality Reduction via Maximum Entropy</a>.
 pdf: http://proceedings.mlr.press/v15/maaten11a/maaten11a.pdf
 section: notable

--- a/_posts/2011-06-14-mahapatruni11a.md
+++ b/_posts/2011-06-14-mahapatruni11a.md
@@ -14,7 +14,7 @@ abstract: In this paper we present a generalization of kernel density estimation
   literature for handling heterogeneous smoothness on different synthetic and natural
   distributions.  [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/mahapatruni11a/mahapatruni11a.pdf
-supplementary: http://proceedings.mlr.press/v15/mahapatruni11a///jmlr.org/proceedings/papers/v15/mahapatruni11a/mahapatruni11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/mahapatruni11a/mahapatruni11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: mahapatruni11a

--- a/_posts/2011-06-14-martins11a.md
+++ b/_posts/2011-06-14-martins11a.md
@@ -9,7 +9,7 @@ abstract: Training structured predictors often requires a considerable time sele
   bounds. Experiments on handwriting recognition and dependency parsing attest the
   success of the approach. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/martins11a/martins11a.pdf
-supplementary: http://proceedings.mlr.press/v15/martins11a///jmlr.org/proceedings/papers/v15/martins11a/martins11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/martins11a/martins11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: martins11a

--- a/_posts/2011-06-14-mcmahan11a.md
+++ b/_posts/2011-06-14-mcmahan11a.md
@@ -1,6 +1,6 @@
 ---
 title: Discussion of “Contextual Bandit Algorithms with Supervised Learning Guarantees”
-abstract: Discussion of <a href="http://jmlr.org/proceedings/papers/v15/beygelzimer11a.html">Contextual
+abstract: Discussion of <a href="http:beygelzimer11a.html">Contextual
   Bandit Algorithms with Supervised Learning Guarantees</a>.
 pdf: http://proceedings.mlr.press/v15/mcmahan11a/mcmahan11a.pdf
 section: notable

--- a/_posts/2011-06-14-niu11b.md
+++ b/_posts/2011-06-14-niu11b.md
@@ -12,7 +12,7 @@ abstract: 'The large volume principle proposed by Vladimir Vapnik, which advocat
   show that the proposed MVC approach compares favorably with state-of-the-art clustering
   algorithms. [pdf][supplementary]'
 pdf: http://proceedings.mlr.press/v15/niu11b/niu11b.pdf
-supplementary: http://proceedings.mlr.press/v15/niu11b///jmlr.org/proceedings/papers/v15/niu11b/niu11bSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/niu11b/niu11bSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: niu11b

--- a/_posts/2011-06-14-odalric11a.md
+++ b/_posts/2011-06-14-odalric11a.md
@@ -17,7 +17,7 @@ abstract: 'We consider multi-armed bandit games with possibly adaptive opponents
   scale poorly with the number of models |Θ|. Our contribution here is to provide
   tractable algorithms with regret bounded by T^2/3C^1/3\log(|Θ|)^1/2. [pdf][supplementary]'
 pdf: http://proceedings.mlr.press/v15/odalric11a/odalric11a.pdf
-supplementary: http://proceedings.mlr.press/v15/odalric11a///jmlr.org/proceedings/papers/v15/odalric11a/odalric11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/odalric11a/odalric11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: odalric11a

--- a/_posts/2011-06-14-peltonen11a.md
+++ b/_posts/2011-06-14-peltonen11a.md
@@ -13,7 +13,7 @@ abstract: Information visualization has recently been formulated as an informati
   The model outperforms earlier models in terms of precision and recall and in external
   validation by unsupervised classification. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/peltonen11a/peltonen11a.pdf
-supplementary: http://proceedings.mlr.press/v15/peltonen11a///jmlr.org/proceedings/papers/v15/peltonen11a/peltonen11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/peltonen11a/peltonen11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: peltonen11a

--- a/_posts/2011-06-14-plis11a.md
+++ b/_posts/2011-06-14-plis11a.md
@@ -15,7 +15,7 @@ abstract: Distributions over permutations arise in applications ranging from mul
   for a state-space model over permutations.  We demonstrate the approach with applications
   and comparisons to existing models. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/plis11a/plis11a.pdf
-supplementary: http://proceedings.mlr.press/v15/plis11a///jmlr.org/proceedings/papers/v15/plis11a/plis11aSupple.zip
+supplementary: http://proceedings.mlr.press/v15/plis11a/plis11aSupple.zip
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: plis11a

--- a/_posts/2011-06-14-ravikumar11a.md
+++ b/_posts/2011-06-14-ravikumar11a.md
@@ -16,7 +16,7 @@ abstract: 'We examine the consistency of listwise ranking methods with respect t
   our theoretical results leads to further improvements over NDCG consistent versions
   of existing surrogates. [pdf][supplementary]'
 pdf: http://proceedings.mlr.press/v15/ravikumar11a/ravikumar11a.pdf
-supplementary: http://proceedings.mlr.press/v15/ravikumar11a///jmlr.org/proceedings/papers/v15/ravikumar11a/ravikumar11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/ravikumar11a/ravikumar11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: ravikumar11a

--- a/_posts/2011-06-14-shamir11a.md
+++ b/_posts/2011-06-14-shamir11a.md
@@ -10,7 +10,7 @@ abstract: Spectral clustering is a modern and well known method for performing d
   and are also relevant for the problem of speeding up standard spectral clustering.
   [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/shamir11a/shamir11a.pdf
-supplementary: http://proceedings.mlr.press/v15/shamir11a///jmlr.org/proceedings/papers/v15/shamir11a/shamir11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/shamir11a/shamir11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: shamir11a

--- a/_posts/2011-06-14-silva11a.md
+++ b/_posts/2011-06-14-silva11a.md
@@ -9,7 +9,7 @@ abstract: Directed acyclic graphs (DAGs) are a popular framework to express mult
   one general construction for ADMG models. We consider a simple parameter estimation
   approach, and report some encouraging experimental results.  [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/silva11a/silva11a.pdf
-supplementary: http://proceedings.mlr.press/v15/silva11a///jmlr.org/proceedings/papers/v15/silva11a/silva11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/silva11a/silva11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: silva11a

--- a/_posts/2011-06-14-sinn11a.md
+++ b/_posts/2011-06-14-sinn11a.md
@@ -11,7 +11,7 @@ abstract: In this theoretical paper we develop an asymptotic theory for Linear-C
   Hessian of the likelihood function and that, asymptotically, the state feature functions
   do not matter.  [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/sinn11a/sinn11a.pdf
-supplementary: http://proceedings.mlr.press/v15/sinn11a///jmlr.org/proceedings/papers/v15/sinn11a/sinn11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/sinn11a/sinn11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: sinn11a

--- a/_posts/2011-06-14-situ11a.md
+++ b/_posts/2011-06-14-situ11a.md
@@ -15,7 +15,7 @@ abstract: In typical classification problems, high level concept features provid
   cancer screening and public datasets. Our results show that the performance of the
   proposed method is highly competitive compared to other relevant methods. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/situ11a/situ11a.pdf
-supplementary: http://proceedings.mlr.press/v15/situ11a///jmlr.org/proceedings/papers/v15/situ11a/situ11aSupple.zip
+supplementary: http://proceedings.mlr.press/v15/situ11a/situ11aSupple.zip
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: situ11a

--- a/_posts/2011-06-14-song11a.md
+++ b/_posts/2011-06-14-song11a.md
@@ -18,7 +18,7 @@ abstract: 'We propose a nonparametric generalization of belief propagation, Kern
   approaches (by orders of magnitude, in some cases), while providing significantly
   more accurate results. [pdf][supplementary]'
 pdf: http://proceedings.mlr.press/v15/song11a/song11a.pdf
-supplementary: http://proceedings.mlr.press/v15/song11a///jmlr.org/proceedings/papers/v15/song11a/song11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/song11a/song11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: song11a

--- a/_posts/2011-06-14-stoyanov11a.md
+++ b/_posts/2011-06-14-stoyanov11a.md
@@ -10,7 +10,7 @@ abstract: Graphical models are often used “inappropriately,” with approximat
   approximate MAP parameters, our approach significantly reduces loss on test data,
   sometimes by an order of magnitude. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/stoyanov11a/stoyanov11a.pdf
-supplementary: http://proceedings.mlr.press/v15/stoyanov11a///jmlr.org/proceedings/papers/v15/stoyanov11a/stoyanov11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/stoyanov11a/stoyanov11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: stoyanov11a

--- a/_posts/2011-06-14-trapeznikov11a.md
+++ b/_posts/2011-06-14-trapeznikov11a.md
@@ -18,7 +18,7 @@ abstract: Active learning deals with the problem of selecting a small subset of 
   ActBoost on several datasets to illustrate its performance and demonstrate its robustness
   to initialization. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/trapeznikov11a/trapeznikov11a.pdf
-supplementary: http://proceedings.mlr.press/v15/trapeznikov11a///jmlr.org/proceedings/papers/v15/trapeznikov11a/trapeznikov11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/trapeznikov11a/trapeznikov11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: trapeznikov11a

--- a/_posts/2011-06-14-wood11a.md
+++ b/_posts/2011-06-14-wood11a.md
@@ -1,7 +1,7 @@
 ---
 title: Discussion of “The Discrete Infinite Logistic Normal Distribution for Mixed-Membership
   Modeling”
-abstract: Discussion of <a href="http://jmlr.org/proceedings/papers/v15/paisley11a.html">The
+abstract: Discussion of <a href="http:paisley11a.html">The
   Discrete Infinite Logistic Normal Distribution for Mixed-Membership Modeling</a>.
 pdf: http://proceedings.mlr.press/v15/wood11a/wood11a.pdf
 section: notable

--- a/_posts/2011-06-14-xiong11a.md
+++ b/_posts/2011-06-14-xiong11a.md
@@ -9,7 +9,7 @@ abstract: Statistical anomaly detection typically focuses on finding individual 
   The experimental results show that the proposed models are effective in detecting
   group anomalies. [pdf][supplementary]
 pdf: http://proceedings.mlr.press/v15/xiong11a/xiong11a.pdf
-supplementary: http://proceedings.mlr.press/v15/xiong11a///jmlr.org/proceedings/papers/v15/xiong11a/xiong11aSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/xiong11a/xiong11aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: xiong11a

--- a/_posts/2011-06-14-zawadzki11a.md
+++ b/_posts/2011-06-14-zawadzki11a.md
@@ -10,7 +10,7 @@ abstract: 'First-order programming (FOP) is a new representation language that c
   by demonstrating an implementation of our decision procedure on a simple first-order
   planning problem. [pdf][supplementary]'
 pdf: http://proceedings.mlr.press/v15/zawadzki11a/zawadzki11a.pdf
-supplementary: http://proceedings.mlr.press/v15/zawadzki11a///jmlr.org/proceedings/papers/v15/zawadzki11a/zawadzki11aSupple.tgz
+supplementary: http://proceedings.mlr.press/v15/zawadzki11a/zawadzki11aSupple.tgz
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: zawadzki11a

--- a/_posts/2011-06-14-zhang11b.md
+++ b/_posts/2011-06-14-zhang11b.md
@@ -14,7 +14,7 @@ abstract: "In this paper, we study the generalization bound for an empirical pro
   and it is faster than the results of the generic i.i.d. empirical process (Vapnik,
   1999)."
 pdf: http://proceedings.mlr.press/v15/zhang11b/zhang11b.pdf
-supplementary: http://proceedings.mlr.press/v15/zhang11b///jmlr.org/proceedings/papers/v15/zhang11b/zhang11bSupple.pdf
+supplementary: http://proceedings.mlr.press/v15/zhang11b/zhang11bSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: zhang11b


### PR DESCRIPTION
The links to the supplementary material are broken in these proceedings, and this pull request proposes a fix.

I downloaded the HTML index page to every published volume and grep'd for this problem. It seems to be only v9 and v15 that have this specific problem. But there may be other broken links.